### PR TITLE
Rename ibeis to wbia

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "ibeis_kaggle7"]
-	path = ibeis_kaggle7
-	url = git@github.com:WildbookOrg/whale-identification-2018.git
+[submodule "wbia_kaggle7"]
+	path = wbia_kaggle7
+	url = git@github.com:WildbookOrg/wbia-tpl-kaggle7.git

--- a/README.md
+++ b/README.md
@@ -6,31 +6,31 @@ An example of how to design and use a Python module as a plugin in the IBEIS IA 
 Install this plugin as a Python module using
 
 ```bash
-cd ~/code/ibeis_kaggle7/
+cd ~/code/wbia_kaggle7/
 python setup.py develop
 ```
 
 # REST API
 
 With the plugin installed, register the module name with the `IBEISControl.py` file
-in the ibeis repository located at `ibeis/ibeis/control/IBEISControl.py`.  Register
-the module by adding the string (for example, `ibeis_kaggle7`) to the
+in the wbia repository located at `wbia/wbia/control/IBEISControl.py`.  Register
+the module by adding the string (for example, `wbia_kaggle7`) to the
 list `AUTOLOAD_PLUGIN_MODNAMES`.
 
 Then, load the web-based IBEIS IA service and open the URL that is registered with
 the `@register_api decorator`.
 
 ```bash
-cd ~/code/ibeis/
+cd ~/code/wbia/
 python dev.py --web
 ```
 
 Navigate in a browser to http://127.0.0.1:5000/api/plugin/example/helloworld/ where
 this returns a formatted JSON response, including the serialized returned value
-from the `ibeis_kaggle7_hello_world()` function
+from the `wbia_kaggle7_hello_world()` function
 
 ```
-{"status": {"cache": -1, "message": "", "code": 200, "success": true}, "response": "[ibeis_kaggle7] hello world with IBEIS controller <IBEISController(testdb1) at 0x11e776e90>"}
+{"status": {"cache": -1, "message": "", "code": 200, "success": true}, "response": "[wbia_kaggle7] hello world with IBEIS controller <IBEISController(testdb1) at 0x11e776e90>"}
 ```
 
 # Python API
@@ -41,21 +41,21 @@ python
 Python 2.7.14 (default, Sep 27 2017, 12:15:00)
 [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)] on darwin
 Type "help", "copyright", "credits" or "license" for more information.
->>> import ibeis
->>> ibs = ibeis.opendb()
+>>> import wbia
+>>> ibs = wbia.opendb()
 
 [ibs.__init__] new IBEISController
 [ibs._init_dirs] ibs.dbdir = u'/Datasets/testdb1'
-[depc] Initialize ANNOTATIONS depcache in u'/Datasets/testdb1/_ibsdb/_ibeis_cache'
-[depc] Initialize IMAGES depcache in u'/Datasets/testdb1/_ibsdb/_ibeis_cache'
+[depc] Initialize ANNOTATIONS depcache in u'/Datasets/testdb1/_ibsdb/_wbia_cache'
+[depc] Initialize IMAGES depcache in u'/Datasets/testdb1/_ibsdb/_wbia_cache'
 [ibs.__init__] END new IBEISController
 
->>> ibs.ibeis_kaggle7_hello_world()
-'[ibeis_kaggle7] hello world with IBEIS controller <IBEISController(testdb1) at 0x10b24c9d0>'
+>>> ibs.wbia_kaggle7_hello_world()
+'[wbia_kaggle7] hello world with IBEIS controller <IBEISController(testdb1) at 0x10b24c9d0>'
 ```
 
 The function from the plugin is automatically added as a method to the ibs object
-as `ibs.ibeis_kaggle7_hello_world()`, which is registered using the
+as `ibs.wbia_kaggle7_hello_world()`, which is registered using the
 `@register_ibs_method decorator`.
 
 

--- a/_doc/Makefile
+++ b/_doc/Makefile
@@ -4,7 +4,7 @@
 # You can set these variables from the command line.
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
-SPHINXPROJ    = ibeis_kaggle7
+SPHINXPROJ    = wbia_kaggle7
 SOURCEDIR     = .
 BUILDDIR      = _build
 

--- a/_doc/conf.py
+++ b/_doc/conf.py
@@ -7,7 +7,7 @@ import os
 os.environ['IBIES_PARSE_ARGS'] = 'OFF'
 os.environ['UTOOL_AUTOGEN_SPHINX_RUNNING'] = 'ON'
 
-# sys.path.append('~/code/ibeis_kaggle7')
+# sys.path.append('~/code/wbia_kaggle7')
 sys.path.append(os.path.abspath("../"))
 
 autosummary_generate = True
@@ -28,7 +28,7 @@ html_theme_path = ["_themes", ]
 
 # -- Project information -----------------------------------------------------
 
-project = 'ibeis_kaggle7'
+project = 'wbia_kaggle7'
 copyright = '2019, Wild Me'
 author = 'Jason Parham'
 

--- a/_doc/ibeis_kaggle7.rst
+++ b/_doc/ibeis_kaggle7.rst
@@ -1,13 +1,13 @@
-ibeis\_kaggle7 package
+wbia\_kaggle7 package
 ======================
 
 Submodules
 ----------
 
-ibeis\_kaggle7.\_plugin module
+wbia\_kaggle7.\_plugin module
 ------------------------------
 
-.. automodule:: ibeis_kaggle7._plugin
+.. automodule:: wbia_kaggle7._plugin
     :members:
     :undoc-members:
     :show-inheritance:
@@ -15,7 +15,7 @@ ibeis\_kaggle7.\_plugin module
 Module contents
 ---------------
 
-.. automodule:: ibeis_kaggle7
+.. automodule:: wbia_kaggle7
     :members:
     :undoc-members:
     :show-inheritance:

--- a/_doc/index.rst
+++ b/_doc/index.rst
@@ -1,4 +1,4 @@
-.. ibeis_kaggle7 documentation master file, created by
+.. wbia_kaggle7 documentation master file, created by
    sphinx-quickstart on Wed Aug 15 11:40:25 2018.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
@@ -10,7 +10,7 @@ Welcome to IBEIS Kaggle7 Plug-in documentation!
    :maxdepth: 8
    :caption: Contents:
 
-   ibeis_kaggle7
+   wbia_kaggle7
 
 
 Indices and tables

--- a/run_tests.py
+++ b/run_tests.py
@@ -8,7 +8,7 @@ import utool as ut
 def run_tests():
     # Build module list and run tests
     import sys
-    ut.change_term_title('RUN ibeis_kaggle7 TESTS')
+    ut.change_term_title('RUN wbia_kaggle7 TESTS')
     exclude_doctests_fnames = set([
     ])
     exclude_dirs = [
@@ -16,7 +16,7 @@ def run_tests():
         '_page',
         '*.egg-info',
     ]
-    dpath_list = ['ibeis_kaggle7']
+    dpath_list = ['wbia_kaggle7']
     doctest_modname_list = ut.find_doctestable_modnames(
         dpath_list, exclude_doctests_fnames, exclude_dirs)
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ MAINTAINER          = 'Wildbook Org. | IBEIS IA'
 MAINTAINER_EMAIL    = 'info@wildme.org'
 DESCRIPTION         = 'A plugin that wraps the Kaggle7 algorithm.'
 LONG_DESCRIPTION    = DESCRIPTION
-KEYWORDS            = ['ibeis', 'plugin', 'identification', 'wildbook', 'ia']
+KEYWORDS            = ['wbia', 'plugin', 'identification', 'wildbook', 'ia']
 URL                 = 'https://github.com/WildbookOrg/'
 DOWNLOAD_URL        = ''
 LICENSE             = 'Apache'
@@ -42,7 +42,7 @@ MINOR               = 1
 MICRO               = 0
 SUFFIX              = 'dev0'
 VERSION             = '%d.%d.%d.%s' % (MAJOR, MINOR, MICRO, SUFFIX)
-PACKAGES            = ['ibeis_kaggle7']
+PACKAGES            = ['wbia_kaggle7']
 
 
 def git_version():
@@ -74,7 +74,7 @@ def git_version():
     return git_revision
 
 
-def write_version_py(filename=os.path.join('ibeis_kaggle7', 'version.py')):
+def write_version_py(filename=os.path.join('wbia_kaggle7', 'version.py')):
     cnt = '''
 # THIS FILE IS GENERATED FROM SETUP.PY
 version = '%(version)s'


### PR DESCRIPTION
- Rename ibeis_kaggle7 to wbia_kaggle7

  We are in the middle of renaming our repos from ibeis to wbia.  Also
  update `.gitmodules` to use the updated repo url.

- Rename ibeis references to wbia

  We are in the middle of renaming our repos from ibeis to wbia.
