### PR TITLE
Remove all __future__ imports

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function
 import sys
 import utool as ut
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, print_function, division
 import subprocess
 import os
 import sys


### PR DESCRIPTION
We added `__future__` imports for python 2.  Now that we are using
python 3.6 or above, they are no longer necessary.

The imports removed are:

- `absolute_import`
- `division`
- `print_function`